### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ WEBDAV_BASEURL=""
 WEBDAV_USERNAME=
 WEBDAV_PASSWORD=
 
-#optional
+# Optional
 WEBDAV_PROXY=
 WEBDAV_PATHPREFIX=""
 WEBDAV_AUTHTYPE=
@@ -38,9 +38,9 @@ WEBDAV_ENCODING=
 	    'userName'   => env("WEBDAV_USERNAME"),
 	    'password'   => env("WEBDAV_PASSWORD"),
 	    
-	    //Optional prameters
+	    // Optional prameters
 	    'proxy'      => env("WEBDAV_PROXY", null),
-	    'pathPrefix' => env("WEBDAV_PATHPREFIX", null),
+	    'pathPrefix' => env("WEBDAV_PATHPREFIX", ''),
 	    'authType'   => env("WEBDAV_AUTHTYPE", null),
 	    'encoding'   => env("WEBDAV_ENCODING", null),
 	],
@@ -54,7 +54,6 @@ After adding the config entry you can use it in your storage driver.
 
 ```php
 Storage::disk('webdav')->files('...')
-
 ```
 
 ## Contributing


### PR DESCRIPTION
`pathPrefix` must be a `string` and cannot be `null` otherwise I keep getting this error:

> League\Flysystem\WebDAV\WebDAVAdapter::__construct(): Argument #2 ($prefix) must be of type string, null given, called in vendor/singlequote/laravel-webdav/src/WebDavServiceProvider.php on line 24